### PR TITLE
Add support for previewing in customizer in WordPress 4.7-beta1

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -200,5 +200,23 @@ add_action( 'after_setup_theme', 'anadama_jetpack_setup' );
 function anadama_customize_register( WP_Customize_Manager $wp_customize ) {
 	$wp_customize->get_setting( 'blogname' )->transport        = 'postMessage';
 	$wp_customize->get_setting( 'blogdescription' )->transport = 'postMessage';
+
+	add_filter( 'wp_get_nav_menu_items', '_anadama_filter_wp_api_nav_menu_items_workaround', 20  );
 }
 add_action( 'customize_register', 'anadama_customize_register' );
+
+/**
+ * Workaround issue in WP API Menus plugin to force nav menu item classes to be arrays instead of strings.
+ *
+ * @see \WP_REST_Menus::get_menu_location()
+ *
+ * @param array $items Nav menu items.
+ */
+function _anadama_filter_wp_api_nav_menu_items_workaround( $items ) {
+	foreach ( $items as &$item ) {
+		if ( is_string( $item->classes ) ) {
+			$item->classes = explode( ' ', $item->classes );
+		}
+	}
+	return $items;
+}

--- a/functions.php
+++ b/functions.php
@@ -97,6 +97,10 @@ add_action( 'after_setup_theme', 'anadama_content_width', 0 );
  * Enqueue scripts and styles.
  */
 function anadama_scripts() {
+	if ( is_customize_preview() ) {
+		wp_enqueue_script( 'anadama-customize-preview', get_template_directory_uri() . '/js/customize-preview.js', array( 'jquery', 'customize-preview' ), ANADAMA_VERSION, true );
+	}
+
 	wp_enqueue_style( 'anadama-style', get_stylesheet_uri() );
 	wp_enqueue_script( 'anadama-react', get_template_directory_uri() . '/js/app.js', array( 'jquery' ), ANADAMA_VERSION, true );
 
@@ -187,3 +191,14 @@ function anadama_jetpack_setup() {
 	add_theme_support( 'site-logo' );
 }
 add_action( 'after_setup_theme', 'anadama_jetpack_setup' );
+
+/**
+ * Register customizer settings.
+ *
+ * @param WP_Customize_Manager $wp_customize Customize manager.
+ */
+function anadama_customize_register( WP_Customize_Manager $wp_customize ) {
+	$wp_customize->get_setting( 'blogname' )->transport        = 'postMessage';
+	$wp_customize->get_setting( 'blogdescription' )->transport = 'postMessage';
+}
+add_action( 'customize_register', 'anadama_customize_register' );

--- a/functions.php
+++ b/functions.php
@@ -98,7 +98,7 @@ add_action( 'after_setup_theme', 'anadama_content_width', 0 );
  */
 function anadama_scripts() {
 	if ( is_customize_preview() ) {
-		wp_enqueue_script( 'anadama-customize-preview', get_template_directory_uri() . '/js/customize-preview.js', array( 'jquery', 'customize-preview' ), ANADAMA_VERSION, true );
+		wp_enqueue_script( 'anadama-customize-preview', get_template_directory_uri() . '/js/customize-preview.js', array( 'jquery', 'customize-preview', 'customize-preview-nav-menus' ), ANADAMA_VERSION, true );
 	}
 
 	wp_enqueue_style( 'anadama-style', get_stylesheet_uri() );

--- a/functions.php
+++ b/functions.php
@@ -103,8 +103,9 @@ function anadama_scripts() {
 	$url = trailingslashit( home_url() );
 	$path = trailingslashit( parse_url( $url, PHP_URL_PATH ) );
 
-	wp_localize_script( 'anadama-react', 'AnadamaSettings', array(
+	wp_scripts()->add_data( 'anadama-react', 'data', sprintf( 'var AnadamaSettings = %s;', wp_json_encode( array(
 		'nonce' => wp_create_nonce( 'wp_rest' ),
+		'localStorageCache' => ! is_customize_preview(),
 		'user' => get_current_user_id(),
 		'title' => get_bloginfo( 'name', 'display' ),
 		'path' => $path,
@@ -113,7 +114,7 @@ function anadama_scripts() {
 			'menuApi' => esc_url_raw( get_rest_url( null, '/wp-api-menus/v2' ) ),
 			'root' => esc_url_raw( $url ),
 		),
-	) );
+	) ) ) );
 }
 add_action( 'wp_enqueue_scripts', 'anadama_scripts' );
 

--- a/js/customize-preview.js
+++ b/js/customize-preview.js
@@ -1,0 +1,18 @@
+
+( function( $, api ) {
+
+	// Site title.
+	api( 'blogname', function( value ) {
+		value.bind( function( to ) {
+			$( '.site-title a' ).text( to );
+		} );
+	} );
+
+	// Site tagline.
+	api( 'blogdescription', function( value ) {
+		value.bind( function( to ) {
+			$( '.site-description' ).text( to );
+		} );
+	} );
+
+} )( jQuery, wp.customize );

--- a/js/customize-preview.js
+++ b/js/customize-preview.js
@@ -15,4 +15,32 @@
 		} );
 	} );
 
+	/**
+	 * Override the handler for clicking links in preview to allow history.pushState() to do its thing.
+	 *
+	 * @param {jQuery.Event} event Event.
+	 */
+	api.Preview.prototype.handleLinkClick = function handleLinkClick( event ) {
+		var link, isInternalJumpLink;
+		link = $( event.target );
+
+		// No-op if the anchor is not a link.
+		if ( _.isUndefined( link.attr( 'href' ) ) ) {
+			return;
+		}
+
+		isInternalJumpLink = ( '#' === link.attr( 'href' ).substr( 0, 1 ) );
+
+		// Allow internal jump links to behave normally without preventing default.
+		if ( isInternalJumpLink ) {
+			return;
+		}
+
+		// If the link is not previewable, prevent the browser from navigating to it.
+		if ( ! api.isLinkPreviewable( link[0] ) ) {
+			wp.a11y.speak( api.settings.l10n.linkUnpreviewable );
+			event.preventDefault();
+		}
+	};
+
 } )( jQuery, wp.customize );

--- a/js/index.jsx
+++ b/js/index.jsx
@@ -12,6 +12,8 @@ require( 'babel-polyfill' );
 // External dependencies
 import page from 'page';
 
+import API from 'utils/api';
+
 // Internal dependencies
 import Controller from './components/controller';
 
@@ -28,3 +30,8 @@ page( /^(?!wp-admin).*/, Controller.setup, Controller.navigation, Controller.pos
 document.addEventListener( 'DOMContentLoaded', function() {
 	page.start();
 } );
+
+module.exports = {
+	page: page,
+	api: API,
+};

--- a/js/index.jsx
+++ b/js/index.jsx
@@ -25,4 +25,6 @@ page( 'tag/:term',      Controller.setup, Controller.navigation, Controller.term
 
 page( /^(?!wp-admin).*/, Controller.setup, Controller.navigation, Controller.post );
 
-page.start();
+document.addEventListener( 'DOMContentLoaded', function() {
+	page.start();
+} );

--- a/js/utils/api.js
+++ b/js/utils/api.js
@@ -57,9 +57,7 @@ export default {
 					AnadamaSettings.URL.api + '/posts/',
 					{
 						per_page: 20,
-						filter: {
-							category_name: category.slug
-						}
+						categories: category.id
 					}
 				) );
 			} );
@@ -119,9 +117,9 @@ export default {
 		} );
 	},
 
-	// Get /{post_type}/?filter[name]={slug}
+	// Get /{post_type}/?slug={slug}
 	getPost: function( slug, type ) {
-		const url = `${AnadamaSettings.URL.api}/${type}s/?filter[name]=${slug}`;
+		const url = `${AnadamaSettings.URL.api}/${type}s/?slug=${slug}`;
 
 		jQuery.when(
 			_get( url, {} )

--- a/js/utils/api.js
+++ b/js/utils/api.js
@@ -44,6 +44,7 @@ export default {
 	// args: might have pagination.
 	getPosts: function( args ) {
 		const url = AnadamaSettings.URL.api + '/categories/';
+		var deferred = jQuery.Deferred();
 		// args.hide_empty = true; // disabled until the API fixes boolean params
 		args.per_page = 10;
 
@@ -79,9 +80,13 @@ export default {
 					}
 				} );
 
+				deferred.resolve( results );
 				PostActions.fetch( data );
+			} ).fail( function( ...results ) {
+				deferred.reject( ...results );
 			} );
 		} );
+		return deferred.promise();
 	},
 
 	// Get posts in a category
@@ -92,7 +97,7 @@ export default {
 			per_page: 20,
 		};
 
-		jQuery.when(
+		return jQuery.when(
 			_get( url, args )
 		).done( function( data ) {
 			// Fetch expects an array of arrays, thanks to the category setup above.
@@ -107,7 +112,7 @@ export default {
 			search: args.term
 		};
 
-		jQuery.when(
+		return jQuery.when(
 			_get( url, args )
 		).done( function( data ) {
 			if ( data.constructor === Array ) {
@@ -121,7 +126,7 @@ export default {
 	getPost: function( slug, type ) {
 		const url = `${AnadamaSettings.URL.api}/${type}s/?slug=${slug}`;
 
-		jQuery.when(
+		return jQuery.when(
 			_get( url, {} )
 		).done( function( data ) {
 			if ( data.constructor === Array ) {
@@ -135,7 +140,7 @@ export default {
 	getMenu: function( path ) {
 		const url = AnadamaSettings.URL.menuApi + path;
 
-		jQuery.when(
+		return jQuery.when(
 			_get( url, {} )
 		).done( function( data ) {
 			NavActions.fetch( data );

--- a/js/utils/api.js
+++ b/js/utils/api.js
@@ -18,7 +18,7 @@ const _get = function( url, data ) {
 
 	return jQuery.ajax( {
 		url: url,
-		data: data,
+		data: jQuery.extend( {}, data, { _wpnonce: AnadamaSettings.nonce } ),
 		dataType: 'json',
 		success: ( returnData ) => {
 			if ( AnadamaSettings.localStorageCache ) {

--- a/js/utils/api.js
+++ b/js/utils/api.js
@@ -11,7 +11,7 @@ import NavActions from '../actions/nav-actions';
 const _get = function( url, data ) {
 	const cacheKey = url.replace( AnadamaSettings.URL.root, '' ) + JSON.stringify( data );
 	let postData = JSON.parse( localStorage.getItem( cacheKey ) );
-	if ( postData ) {
+	if ( postData && AnadamaSettings.localStorageCache ) {
 		let dfd = new jQuery.Deferred;
 		return dfd.resolve( postData );
 	}
@@ -21,7 +21,9 @@ const _get = function( url, data ) {
 		data: data,
 		dataType: 'json',
 		success: ( returnData ) => {
-			localStorage.setItem( cacheKey, JSON.stringify( returnData ) );
+			if ( AnadamaSettings.localStorageCache ) {
+				localStorage.setItem( cacheKey, JSON.stringify( returnData ) );
+			}
 		}
 	} );
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,8 @@ module.exports = {
 		path: path.resolve( __dirname, './js' ),
 		filename: '[name].js',
 		chunkFilename: '[id].js',
+		libraryTarget: "var",
+		library: "Anadama"
 	},
 	resolve: {
 		extensions: [ '', '.js', '.jsx' ],


### PR DESCRIPTION
The customizer in WordPress 4.7 includes the customized state in REST API requests so that the previewed changes will apply in the responses. Additionally, the customizer preview is now compatible with JS-routed apps which use `history.pushState()` and `history.replaceState()`. See [Customize Changesets Technical Design Decisions](https://make.wordpress.org/core/2016/10/12/customize-changesets-technical-design-decisions/). These changes mean that Anadama can now be live previewed in the customizer, as long as a few things are done to facilitate the integration.

Some highlights from the PR:
* Disables `localStorage` cache in the customizer preview so that the previewed state will apply to the requests and so that the cache does not get polluted with staged changes.
* Adds live previewing of site title and tagline using the familiar mechanisms.
* Adds live previewing of changes to the nav menu by overriding the normal selective refresh behavior by instead listening for changes to the nav menu location, the assigned nav menu, or nav menu items inside the nav menu and then refreshing the data for the menu from the server.
* Overrides the normal customizer preview interception of link clicks to allow the JS routing to work as normal. The customizer preview JS wraps the `history.replaceState()` and `history.pushState()` methods to ensure the customizer state params are included in the URLs.
* Updates the theme to be compatible with the REST API endpoints that were merged into 4.7-beta1. Namely, it replaces `filter[name]` and `filter[category_name]` with `slug` and `categories`, respectively.
* Includes the `wp_rest` nonce in REST API requests so that any `customized` data will be read (since the customizer will ignore it for unauthorized requests).

This is my first time implementing customizer support for an SPA theme. There are probably better patterns than what I've implemented here, but my hope is that this will provide some sample code to start getting more JavaScript-driven themes updated to support live previewing in the customizer, and to get some real experience on how the new customizer changes in 4.7 will work in the real world, while also identifying the problem spots and pain points.